### PR TITLE
Make app manifest file search case-insensitive

### DIFF
--- a/DockerForm/DatabaseManager.cs
+++ b/DockerForm/DatabaseManager.cs
@@ -294,7 +294,7 @@ namespace DockerForm
                 foreach (string file in Directory.GetFiles(folder))
                 {
                     FileInfo myFile = new FileInfo(file);
-                    if (myFile.Name.Equals("AppxManifest.xml"))
+                    if (myFile.Name.Equals("AppxManifest.xml", StringComparison.OrdinalIgnoreCase))
                     {
                         XmlDocument doc = new XmlDocument();
                         // prevent crash if file is being read/write by Microsoft Store


### PR DESCRIPTION
AppxManifest.xml in Windows apps does not always match that case. Make the search case-insensitive.